### PR TITLE
Upgrade Semaphore agent to Ubuntu 24 ARM

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: Manual Release Pipeline
 agent:
   machine:
-    type: s1-prod-ubuntu20-04-amd64-1
+    type: s1-prod-ubuntu24-04-arm64-1
     os_image: ''
 blocks:
   - name: Tag and Release


### PR DESCRIPTION
This upgrades the Semaphore agent from Ubuntu 20 to 24 and switches the architecture to ARM. 
1. Ubuntu 20 is EOL and will be decommissioned soon. 
2. This workload is not architecture dependent and ARM is slightly cheaper + faster.